### PR TITLE
fix: avoid duplicate setting in prettierrc

### DIFF
--- a/generators/app/templates/dot_prettierrc.json
+++ b/generators/app/templates/dot_prettierrc.json
@@ -5,6 +5,5 @@
   "singleQuote": true,
   "bracketSpacing": true,
   "arrowParens": "always",
-  "endOfLine": "lf",
   "trailingComma": "all"
 }


### PR DESCRIPTION
From the prettier documentation[^1]:

> If options.editorconfig is true and an .editorconfig file is in your
> project, Prettier will parse it and convert its properties to the
> corresponding Prettier configuration. This configuration will be
> overridden by .prettierrc, etc. Currently, the following EditorConfig
> properties are supported:
>
> - end_of_line
> - indent_style
> - indent_size/tab_width
> - max_line_length

This commit removes the `endOfLine` setting in prettierrc.json in favor
of specifying it in the editorconfig file.

[^1]: https://prettier.io/docs/en/api.html#prettierresolveconfigfilepath--options