### PR TITLE
feat: use indirection to resolve prettier config

### DIFF
--- a/generators/app/templates/dot_prettierignore
+++ b/generators/app/templates/dot_prettierignore
@@ -1,0 +1,3 @@
+.nyc_output/
+dist/
+package-lock.json

--- a/generators/app/templates/dot_prettierrc.json
+++ b/generators/app/templates/dot_prettierrc.json
@@ -1,9 +1,1 @@
-{
-  "tabWidth": 2,
-  "useTabs": false,
-  "semi": false,
-  "singleQuote": true,
-  "bracketSpacing": true,
-  "arrowParens": "always",
-  "trailingComma": "all"
-}
+"@ericcrosson/prettier-config"

--- a/generators/app/templates/package_dot_json
+++ b/generators/app/templates/package_dot_json
@@ -34,7 +34,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@ericcrosson/eslint-config": "^2.0.0",
+    "@ericcrosson/eslint-config": "^2.1.3",
+    "@ericcrosson/prettier-config": "^1.0.0",
     "@types/node": "^14.14.17",
     "@typescript-eslint/eslint-plugin": "^4.11.1",
     "@typescript-eslint/parser": "^4.11.1",

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -189,6 +189,11 @@ module.exports = class extends Generator {
       generateTemplate("dot_editorconfig");
     }
 
+    // There are a few open issues for prettier to respect prettierignore files in a
+    // monorepo root, but for not there is no such behavior.  This means we have to
+    // generate the prettierignore file even in lerna packages.
+    generateTemplate("dot_prettierignore");
+
     generateTemplate("licenses/" + userInput.license.toLowerCase(), "LICENSE");
   }
 


### PR DESCRIPTION
By placing prettier configuration in an external package, we can update
the package and thus all of our generated packages can inherit the
updates with minimal effort.

Closes #194